### PR TITLE
Upgrade pandas and fix deprecation warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 openpyxl
-pandas
+pandas >= 1.5
 more-itertools
 pre-commit
 black

--- a/times_excel_reader.py
+++ b/times_excel_reader.py
@@ -1197,7 +1197,7 @@ def dump_tables(tables: List, filename: str) -> List:
             text_file.write(f"tag: {tag}\n")
             types = ", ".join([f"{i} ({v})" for i, v in df.dtypes.items()])
             text_file.write(f"types: {types}\n")
-            text_file.write(df.to_csv(index=False, line_terminator="\n"))
+            text_file.write(df.to_csv(index=False, lineterminator="\n"))
             text_file.write("\n" * 2)
 
     return tables


### PR DESCRIPTION
This PR fixes this warning:
```
times_excel_reader.py:1200: FutureWarning: the 'line_terminator'' keyword is deprecated, use 'lineterminator' instead.
  text_file.write(df.to_csv(index=False, line_terminator="\n"))
```

PSA: you might need to upgrade your local pandas version. E.g., run
```
pip install -r requirements.txt
```